### PR TITLE
Show contact details when avatar icon is clicked

### DIFF
--- a/src/org/jitsi/android/gui/contactlist/ContactListAdapter.java
+++ b/src/org/jitsi/android/gui/contactlist/ContactListAdapter.java
@@ -349,6 +349,9 @@ public class ContactListAdapter
                 = (TextView) convertView.findViewById(R.id.statusMessage);
             contactViewHolder.avatarView
                 = (ImageView) convertView.findViewById(R.id.avatarIcon);
+	    contactViewHolder.avatarView
+		    .setOnClickListener(avatarIconClickListener);
+	    contactViewHolder.avatarView.setTag(contactViewHolder);
             contactViewHolder.statusView
                 = (ImageView) convertView.findViewById(R.id.contactStatusIcon);
             contactViewHolder.callButton


### PR DESCRIPTION
When avatar icon of a contact is clicked, a toast pops up with the contact's email address/ID. This is an initial implementation, so that the user will have a  quick way to view contact details, without having to open and dismiss a dialog.
