### PR TITLE
Duplicate subexpressions in ConfigEditText.java

### DIFF
--- a/src/org/jitsi/android/gui/settings/widget/ConfigEditText.java
+++ b/src/org/jitsi/android/gui/settings/widget/ConfigEditText.java
@@ -201,7 +201,7 @@ public class ConfigEditText
                 return false;
             }
         }
-        else if(floatMax != null && floatMax != null)
+        else if(floatMax != null && floatMin != null)
         {
             // Float range check
             try


### PR DESCRIPTION
`floatMax != null` is repeated. Looks like this should be `floatMin != null`.